### PR TITLE
stylesheet: Antialiased font rendering on tagline

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -90,7 +90,8 @@ a {
 .project-tagline {
   margin-bottom: 2rem;
   font-weight: normal;
-  opacity: 0.7; }
+  opacity: 0.7;
+  -webkit-font-smoothing: antialiased; }
 
 @media screen and (min-width: 64em) {
   .project-tagline {


### PR DESCRIPTION
Because of opacity usage, use antialiased rendering to get better looking fonts on webkit.

Before antialiased rendering:

![without-antialiasing](https://cloud.githubusercontent.com/assets/1611639/12050972/db64e40c-aee3-11e5-8a06-31b1ac52810f.png)

After antialiased rendering:

![with-antialiasing](https://cloud.githubusercontent.com/assets/1611639/12050976/e32f325a-aee3-11e5-9054-70f7448fad47.png)
