### PR TITLE
Remove node version restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-calendar",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Up-to-date business calendar",
   "main": "index.js",
   "dependencies": {},

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "1.5.0",
   "description": "Up-to-date business calendar",
   "main": "index.js",
-  "engines" : {
-    "node" : ">=8.0.0 <12.0.0"
-  },
   "dependencies": {},
   "devDependencies": {
     "gulp": "3.9.0",


### PR DESCRIPTION
Não faz sentido restringir a versão do node até o 12, pois não utilizamos nenhuma API interna do Node que tenha mudado da 12 em diante